### PR TITLE
ci: run fmt on ubuntu-slim

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,14 @@ jobs:
       run: cargo test --all-features --workspace
 
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
     - uses: actions/checkout@v7
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        components: rustfmt
     - name: cargo-fmt
       run: cargo fmt -- --check
 
@@ -55,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Get minimum supported Rust version
-        run: echo "::set-output name=msrv::$(grep '^rust-version = ' Cargo.toml | grep -o '[0-9.]\+')"
+        run: echo "msrv=$(grep '^rust-version = ' Cargo.toml | grep -o '[0-9.]\+')" >> $GITHUB_OUTPUT
         id: get_msrv
       - uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
`fmt` only checks formatting, so it moves to the single-CPU `ubuntu-slim` runner. It relied on the Rust preinstalled on `ubuntu-latest`, which slim doesn't ship, so the toolchain is now installed explicitly — a pinned toolchain instead of whatever the image happens to carry.

Also replaces the deprecated `::set-output` in `msrv-build` with `$GITHUB_OUTPUT`, matching `light-curve-python`.

Other jobs stay on full runners — all of them compile, including `readme`, which shells out to `cargo run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)